### PR TITLE
treat extensionless as .js

### DIFF
--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -50,7 +50,7 @@ function defaultGetFormat(url, context, defaultGetFormatUnused) {
   } else if (parsed.protocol === 'file:') {
     const ext = extname(parsed.pathname);
     let format;
-    if (ext === '.js') {
+    if (!ext || ext === '.js') {
       format = getPackageType(parsed.href) === 'module' ? 'module' : 'commonjs';
     } else {
       format = extensionFormatMap[ext];

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -14,8 +14,9 @@ const { ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
 const extensionFormatMap = {
   '__proto__': null,
   '.cjs': 'commonjs',
-  '.js': 'module',
-  '.mjs': 'module'
+  '.mjs': 'module',
+  '.json': 'unsupported',
+  '.wasm': 'unsupported'
 };
 
 const legacyExtensionFormatMap = {
@@ -24,7 +25,8 @@ const legacyExtensionFormatMap = {
   '.js': 'commonjs',
   '.json': 'commonjs',
   '.mjs': 'module',
-  '.node': 'commonjs'
+  '.node': 'commonjs',
+  '.wasm': 'unsupported'
 };
 
 if (experimentalWasmModules)
@@ -39,7 +41,7 @@ function defaultGetFormat(url, context, defaultGetFormatUnused) {
   }
   const parsed = new URL(url);
   if (parsed.protocol === 'data:') {
-    const [ , mime ] = /^([^/]+\/[^;,]+)(?:[^,]*?)(;base64)?,/.exec(parsed.pathname) || [ null, null, null ];
+    const [, mime] = /^([^/]+\/[^;,]+)(?:[^,]*?)(;base64)?,/.exec(parsed.pathname) || [null, null, null];
     const format = ({
       '__proto__': null,
       'text/javascript': 'module',
@@ -49,21 +51,20 @@ function defaultGetFormat(url, context, defaultGetFormatUnused) {
     return { format };
   } else if (parsed.protocol === 'file:') {
     const ext = extname(parsed.pathname);
-    let format;
-    if (!ext || ext === '.js') {
-      format = getPackageType(parsed.href) === 'module' ? 'module' : 'commonjs';
-    } else {
-      format = extensionFormatMap[ext];
-    }
+    let format = extensionFormatMap[ext];
     if (!format) {
       if (experimentalSpeciferResolution === 'node') {
         process.emitWarning(
           'The Node.js specifier resolution in ESM is experimental.',
           'ExperimentalWarning');
         format = legacyExtensionFormatMap[ext];
-      } else {
-        throw new ERR_UNKNOWN_FILE_EXTENSION(ext, fileURLToPath(url));
       }
+    }
+    if (format === 'unsupported') {
+      throw new ERR_UNKNOWN_FILE_EXTENSION(ext, fileURLToPath(url));
+    }
+    if (!format) {
+      format = getPackageType(parsed.href) === 'module' ? 'module' : 'commonjs';
     }
     return { format: format || null };
   }

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -21,9 +21,6 @@ function resolveMainPath(main) {
 }
 
 function shouldUseESMLoader(mainPath) {
-  const userLoader = getOptionValue('--experimental-loader');
-  if (userLoader)
-    return true;
   const esModuleSpecifierResolution =
     getOptionValue('--es-module-specifier-resolution');
   if (esModuleSpecifierResolution === 'node')
@@ -41,7 +38,7 @@ function runMainESM(mainPath) {
   const esmLoader = require('internal/process/esm_loader');
   const { pathToFileURL } = require('internal/url');
   const { hasUncaughtExceptionCaptureCallback } =
-      require('internal/process/execution');
+    require('internal/process/execution');
   return esmLoader.initializeLoader().then(() => {
     const main = path.isAbsolute(mainPath) ?
       pathToFileURL(mainPath).href : mainPath;

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -21,6 +21,9 @@ function resolveMainPath(main) {
 }
 
 function shouldUseESMLoader(mainPath) {
+  const userLoader = getOptionValue('--experimental-loader');
+  if (userLoader)
+    return true;
   const esModuleSpecifierResolution =
     getOptionValue('--es-module-specifier-resolution');
   if (esModuleSpecifierResolution === 'node')
@@ -38,7 +41,7 @@ function runMainESM(mainPath) {
   const esmLoader = require('internal/process/esm_loader');
   const { pathToFileURL } = require('internal/url');
   const { hasUncaughtExceptionCaptureCallback } =
-    require('internal/process/execution');
+      require('internal/process/execution');
   return esmLoader.initializeLoader().then(() => {
     const main = path.isAbsolute(mainPath) ?
       pathToFileURL(mainPath).href : mainPath;


### PR DESCRIPTION
@guybedford

These two separate commits address the issue of using extensionless modules:

34a0f30 - extensionless files will be treated as .js 
69a29ee - using the `--loader` flag will not force using ESM loader 